### PR TITLE
first implementation of annotation track 

### DIFF
--- a/tsqc/__main__.py
+++ b/tsqc/__main__.py
@@ -14,6 +14,7 @@ import panel as pn  # noqa
 
 from . import model  # noqa
 from . import pages  # noqa
+from . import config  # noqa
 
 logger = daiquiri.getLogger("tsqc")
 
@@ -116,6 +117,7 @@ def setup_logging(log_level, no_log_filter):
 
 @click.command()
 @click.argument("path", type=click.Path(exists=True, dir_okay=False))
+@click.option("--annotations-file", type=click.Path(exists=True, dir_okay=False))
 @click.option("--port", default=8080, help="Port to serve on")
 @click.option(
     "--show/--no-show",
@@ -129,12 +131,15 @@ def setup_logging(log_level, no_log_filter):
     is_flag=True,
     help="Do not filter the output log (advanced debugging only)",
 )
-def main(path, port, show, log_level, no_log_filter):
+def main(path, port, show, log_level, no_log_filter, annotations_file):
     """
     Run the tsqc server.
     """
     setup_logging(log_level, no_log_filter)
+
     tsm = load_data(pathlib.Path(path))
+    if annotations_file:
+        config.ANNOTATIONS_FILE = annotations_file
 
     # Note: functools.partial doesn't work here
     def app():

--- a/tsqc/config.py
+++ b/tsqc/config.py
@@ -2,3 +2,4 @@
 PLOT_WIDTH = 1000
 PLOT_HEIGHT = 600
 THRESHOLD = 1000  # max number of points to overlay on a plot
+ANNOTATIONS_FILE = None  # set through command line option

--- a/tsqc/model.py
+++ b/tsqc/model.py
@@ -501,6 +501,17 @@ class TSModel:
             }
         )
 
+    def genes_df(self, genes_file):
+        genes_df = pd.read_csv(genes_file, sep=";")
+        # TODO file checks!
+        genes_df.columns = ["chr", "position", "end", "strand", "id", "name"]
+        genes_df = genes_df[
+            (genes_df["position"] >= self.ts.first().interval.left)
+            & (genes_df["end"] <= self.ts.last().interval.right)
+        ]
+        logger.info("Computed genes dataframe")
+        return genes_df
+
     def calc_polytomy_fractions(self):
         """
         Calculates the fraction of polytomies for each tree in the


### PR DESCRIPTION
adds a basic gene track to the Mutations page when a gene coordinate csv like below is provided
` python -m tsqc path/to/trees --annotate-genes path/to/csv`
![image](https://github.com/tskit-dev/tsqc/assets/25925005/07e344a9-c8c6-4486-bbf8-0c4b5f2369b9)


Few issues to iron out:
> input annotation file format checks. (I guess it might be better to switch to a standard bed or gtf format file at some point.)
> subset annotation data to the same chromosome as tree sequence
> restrict y zooming on the genome and tree tracks
